### PR TITLE
OTP with a leading zero does not work and turns into 5 digits when converted to string.

### DIFF
--- a/src/main/java/burp/MySessionHandlingAction.java
+++ b/src/main/java/burp/MySessionHandlingAction.java
@@ -76,12 +76,12 @@ public class MySessionHandlingAction implements SessionHandlingAction
 
     private HttpRequest updateOrAddTokenInHeader(HttpRequest request)
     {
-        return isParameterNamePresentInHeaders(request) ? request.withUpdatedHeader(httpHeader(parameterName, String.valueOf(gAuth.getTotpPassword(secret)))) : request.withAddedHeader(httpHeader(parameterName, String.valueOf(gAuth.getTotpPassword(secret))));
+        return isParameterNamePresentInHeaders(request) ? request.withUpdatedHeader(httpHeader(parameterName, String.format("%06d", gAuth.getTotpPassword(secret)))) : request.withAddedHeader(httpHeader(parameterName, String.format("%06d", gAuth.getTotpPassword(secret))));
     }
 
     private HttpRequest updateOrAddTokenInParameter(HttpRequest request, HttpParameterType parameterType)
     {
-        return isParameterNamePresentInParameters(request, parameterType) ? request.withUpdatedParameters(parameter(parameterName, String.valueOf(gAuth.getTotpPassword(secret)), parameterType)) : request.withAddedParameters(parameter(parameterName, String.valueOf(gAuth.getTotpPassword(secret)), parameterType));
+        return isParameterNamePresentInParameters(request, parameterType) ? request.withUpdatedParameters(parameter(parameterName, String.format("%06d", gAuth.getTotpPassword(secret)), parameterType)) : request.withAddedParameters(parameter(parameterName, String.format("%06d", gAuth.getTotpPassword(secret)), parameterType));
     }
 
     private HttpRequest updateTokenInBody(HttpRequest request)
@@ -93,7 +93,8 @@ public class MySessionHandlingAction implements SessionHandlingAction
         {
             int start = matcher.start(1);
             int end = matcher.end(1);
-            return request.withBody(new StringBuilder(body).replace(start, end, String.valueOf(gAuth.getTotpPassword(secret))).toString());
+            return request.withBody(new StringBuilder(body).replace(start, end, String.format("%06d", gAuth.getTotpPassword(secret))).toString());
+
         }
 
         return request;

--- a/src/main/java/userinterface/UserInterface.java
+++ b/src/main/java/userinterface/UserInterface.java
@@ -141,7 +141,7 @@ public class UserInterface
                 codeUpdateFuture = null;
 
             }
-            codeUpdateFuture = EXECUTOR_SERVICE.scheduleAtFixedRate(() -> currentCode.setText(String.valueOf(AUTHENTICATOR.getTotpPassword(seed))), 0, 30, TimeUnit.SECONDS);
+            codeUpdateFuture = EXECUTOR_SERVICE.scheduleAtFixedRate(() -> currentCode.setText(String.format("%06d", AUTHENTICATOR.getTotpPassword(seed))), 0, 30, TimeUnit.SECONDS);
         }
 
 


### PR DESCRIPTION
For example when OTP code is 012345, the request modified by extension turns it into 12345 causing login failures.

This PR ensures all OTPs in the following locations to be 6 digits even when starting with a zero.

- Body params (URL, Header, Cookie and Body)
- Body Regex
- Extension UI (Burp Pro only)

BTW, thanks to this amazing extension specially making it compatible with Burp Enterprise.